### PR TITLE
Fast MCP input schema description bug workaround.

### DIFF
--- a/app/tools/add_meal_plans_tool.rb
+++ b/app/tools/add_meal_plans_tool.rb
@@ -5,7 +5,7 @@ class AddMealPlansTool < ApplicationTool
 
   arguments do
     required(:token).filled(:string).description("Token of the user's session")
-    required(:meal_plans).value(:array, min_size?: 1).description("Meal plans array of objects: {recipe_id: string, date: date, meal: [breakfast|lunch|dinner|snack]}").each do
+    required(:meal_plans).value(:array, min_size?: 1).description("Meal plans array of objects: [{recipe_id: string, date: date, meal: [breakfast|lunch|dinner|snack]}]").each do
       hash do
         required(:recipe_id).filled(:string).description("Recipe ID")
         required(:date).filled(:date).description("Date of the meal")

--- a/app/tools/add_pantry_items_tool.rb
+++ b/app/tools/add_pantry_items_tool.rb
@@ -5,7 +5,7 @@ class AddPantryItemsTool < ApplicationTool
 
   arguments do
     required(:token).filled(:string).description("Token of the user's session")
-    required(:pantry_items).array(min_size?: 1).description("Pantry items").each do
+    required(:pantry_items).array(min_size?: 1).description("Pantry items: [{ name: string, quantity: string }]").each do
       hash do
         required(:name).filled(:string).description("Pantry item description")
         required(:quantity).filled(:string).description("Pantry item quantity")

--- a/app/tools/add_recipe_tool.rb
+++ b/app/tools/add_recipe_tool.rb
@@ -7,7 +7,7 @@ class AddRecipeTool < ApplicationTool
     required(:token).filled(:string).description("Token of the user's session")
     required(:title).filled(:string).description("Recipe Title")
     required(:description).filled(:string).description("Recipe description")
-    required(:ingredients).value(:array, min_size?: 1).description("Recipe ingredients").each do
+    required(:ingredients).value(:array, min_size?: 1).description("Recipe ingredients: [{ name: string, quantity: string }]").each do
       hash do
         required(:name).filled(:string)
         required(:quantity).filled(:string)

--- a/app/tools/update_recipe_tool.rb
+++ b/app/tools/update_recipe_tool.rb
@@ -8,7 +8,7 @@ class UpdateRecipeTool < ApplicationTool
     required(:id).filled(:string).description("Recipe ID")
     required(:title).filled(:string).description("Recipe Title")
     required(:description).filled(:string).description("Recipe description")
-    required(:ingredients).value(:array, min_size?: 1).description("Recipe ingredients").each do
+    required(:ingredients).value(:array, min_size?: 1).description("Recipe ingredients: [{ name: string, quantity: string }]").each do
       hash do
         required(:name).filled(:string)
         required(:quantity).filled(:string)


### PR DESCRIPTION
Fast-mcp has a bug in the input schema json generation: https://github.com/yjacquin/fast-mcp/pull/127 so I added a quick description by hand to help LLMs